### PR TITLE
add support for routes with hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+example/bundle.js
+npm-debug.log

--- a/example/build.sh
+++ b/example/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-browserify main.js -o bundle.js

--- a/example/index.html
+++ b/example/index.html
@@ -6,17 +6,17 @@
       foo foO fOo fOO Foo FoO FOo FOO
       <div><a href="/bar">bar</a></div>
     </div>
-    
+
     <div id="bar">
       bar baR bAr bAR Bar BaR BAr BAR
-      <div><a href="/baz">baz</a></div>
+      <div><a href="/#baz">baz</a></div>
     </div>
-    
+
     <div id="baz">
       baz baZ bAz bAZ Baz BaZ BAz BAZ
       <div><a href="/foo">foo</a></div>
     </div>
-    
+
     <script src="bundle.js"></script>
   </body>
 </html>

--- a/example/main.js
+++ b/example/main.js
@@ -1,27 +1,26 @@
-var divs = {
-    foo: document.querySelector('#foo'),
-    bar: document.querySelector('#bar'),
-    baz: document.querySelector('#baz')
-};
+var divs = {}
+divs['foo'] = document.querySelector('#foo')
+divs['bar'] = document.querySelector('#bar')
+divs['#baz'] = document.querySelector('#baz')
 
-var singlePage = require('../');
+var singlePage = require('../')
 var showPage = singlePage(function (href) {
-    Object.keys(divs).forEach(function (key) {
-        hide(divs[key]);
-    });
-    
-    var div = divs[href.replace(/^\//, '')];
-    if (div) show(div)
-    else show(divs.foo)
-    
-    function hide (e) { e.style.display = 'none' }
-    function show (e) { e.style.display = 'block' }
+  Object.keys(divs).forEach(function (key) {
+    hide(divs[key])
+  });
+
+  var div = divs[href.replace(/^\//, '')]
+  if (div) show(div)
+  else show(divs.foo)
+
+  function hide (e) { e.style.display = 'none' }
+  function show (e) { e.style.display = 'block' }
 });
 
-var links = document.querySelectorAll('a[href]');
+var links = document.querySelectorAll('a[href]')
 for (var i = 0; i < links.length; i++) {
-    links[i].addEventListener('click', function (ev) {
-        ev.preventDefault();
-        showPage(this.getAttribute('href'));
-    });
+  links[i].addEventListener('click', function (ev) {
+    ev.preventDefault()
+    showPage(this.getAttribute('href'))
+  })
 }

--- a/example/server.js
+++ b/example/server.js
@@ -1,12 +1,11 @@
-var http = require('http');
-var ecstatic = require('ecstatic')(__dirname);
+var http = require('http')
+var ecstatic = require('ecstatic')(__dirname)
 
 var server = http.createServer(function (req, res) {
-    if (/^\/[^\/.]+$/.test(req.url)) {
-        req.url = '/';
-    }
-    ecstatic(req, res);
-});
-server.listen(5001);
-
-console.log('http://localhost:5001');
+  if (/^\/[^\/.]+$/.test(req.url)) {
+    req.url = '/'
+  }
+  ecstatic(req, res)
+})
+server.listen(5001)
+console.log('Server is running on port 5001')

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ module.exports = function (cb, opts) {
     window.addEventListener('popstate', onpopstate);
     
     function onpopstate () {
-        var href = window.location.pathname;
+        var href = getPathnameWithHash();
         page.show(href);
     }
     process.nextTick(onpopstate);
@@ -13,6 +13,10 @@ module.exports = function (cb, opts) {
     fn.show = function (href) { return page.show(href) };
     return fn;
 };
+
+function getPathnameWithHash () {
+  return (window.location.pathname || '') + (window.location.hash || '');
+}
 
 function Page (cb, opts) {
     if (!opts) opts = {};
@@ -55,6 +59,6 @@ Page.prototype.push = function (href) {
 
 Page.prototype.pushHref = function (href) {
     this.current = href;
-    var mismatched = window.location.pathname !== href;
+    var mismatched = getPathnameWithHash() !== href;
     if (mismatched) window.history.pushState(null, '', href);
 };

--- a/index.js
+++ b/index.js
@@ -1,64 +1,64 @@
 module.exports = function (cb, opts) {
-    var page = new Page(cb, opts);
-    window.addEventListener('popstate', onpopstate);
-    
-    function onpopstate () {
-        var href = getPathnameWithHash();
-        page.show(href);
-    }
-    process.nextTick(onpopstate);
-    
-    var fn = function (href) { return page.show(href) };
-    fn.push = function (href) { return page.push(href) };
-    fn.show = function (href) { return page.show(href) };
-    return fn;
-};
+  var page = new Page(cb, opts)
+  window.addEventListener('popstate', onpopstate)
+
+  function onpopstate () {
+    var href = getPathnameWithHash()
+    page.show(href)
+  }
+  process.nextTick(onpopstate)
+
+  var fn = function (href) { return page.show(href) }
+  fn.push = function (href) { return page.push(href) }
+  fn.show = function (href) { return page.show(href) }
+  return fn
+}
 
 function getPathnameWithHash () {
-  return (window.location.pathname || '') + (window.location.hash || '');
+  return (window.location.pathname || '') + (window.location.hash || '')
 }
 
 function Page (cb, opts) {
-    if (!opts) opts = {};
-    this.current = null;
-    this.hasPushState = opts.pushState !== undefined
-        ? opts.pushState
-        : window.history && window.history.pushState
-    ;
-    this.scroll = opts.saveScroll !== false ? {} : null;
-    this.cb = cb;
+  if (!opts) opts = {}
+  this.current = null
+  this.hasPushState = opts.pushState !== undefined
+    ? opts.pushState
+    : window.history && window.history.pushState
+
+  this.scroll = opts.saveScroll !== false ? {} : null
+  this.cb = cb
 }
 
 Page.prototype.show = function (href) {
-    href = href.replace(/^\/+/, '/');
-     
-    if (this.current === href) return;
-    this.saveScroll(href);
-    this.current = href;
-    
-    var scroll = this.scroll[href];
-    this.cb(href, {
-        scrollX : scroll && scroll[0] || 0,
-        scrollY : scroll && scroll[1] || 0
-    });
-    
-    this.pushHref(href);
-};
+  href = href.replace(/^\/+/, '/')
+
+  if (this.current === href) return
+  this.saveScroll(href)
+  this.current = href
+
+  var scroll = this.scroll[href]
+  this.cb(href, {
+    scrollX : scroll && scroll[0] || 0,
+    scrollY : scroll && scroll[1] || 0
+  })
+
+  this.pushHref(href)
+}
 
 Page.prototype.saveScroll = function (href) {
-    if (this.scroll && this.current) {
-        this.scroll[this.current] = [ window.scrollX, window.scrollY ];
-    }
-};
+  if (this.scroll && this.current) {
+    this.scroll[this.current] = [ window.scrollX, window.scrollY ]
+  }
+}
 
 Page.prototype.push = function (href) {
-    href = href.replace(/^\/+/, '/');
-    this.saveScroll(href);
-    this.pushHref(href);
-};
+  href = href.replace(/^\/+/, '/')
+  this.saveScroll(href)
+  this.pushHref(href)
+}
 
 Page.prototype.pushHref = function (href) {
-    this.current = href;
-    var mismatched = getPathnameWithHash() !== href;
-    if (mismatched) window.history.pushState(null, '', href);
-};
+  this.current = href
+  var mismatched = getPathnameWithHash() !== href
+  if (mismatched) window.history.pushState(null, '', href)
+}

--- a/package.json
+++ b/package.json
@@ -1,26 +1,35 @@
 {
-    "name" : "single-page",
+    "name" : "single-page-hash",
     "version" : "1.0.0",
-    "description" : "write single-page apps with a single callback to handle pushState events",
+    "description" : "write single-page apps with support for url hashes and a single callback to handle pushState events",
     "main" : "index.js",
     "scripts" : {
-        "test" : "tap test/*.js"
+      "start": "npm run www & npm run watch",
+      "www": "node example/server.js",
+      "watch": "watchify example/main.js -o example/bundle.js -dv",
+      "bundle": "browserify example/main.js -o example/bundle.js"
     },
     "repository" : {
         "type" : "git",
-        "url" : "git://github.com/substack/single-page.git"
+        "url" : "git://github.com/serapath/single-page.git"
     },
-    "homepage" : "https://github.com/substack/single-page",
+    "homepage" : "https://github.com/serapath/single-page",
     "keywords" : [
         "pushState",
+        "history",
         "single-page",
+        "single-page-hash",
         "client-side",
         "browser"
     ],
-    "author" : {
+    "contributors" : [{
         "name" : "James Halliday",
         "email" : "mail@substack.net",
         "url" : "http://substack.net"
-    },
+    },{
+      "name" : "Alexander Praetorius",
+      "email" : "dev@serapath.de",
+      "url" : "http://serapath.de"
+    }],
     "license" : "MIT"
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,6 +1,6 @@
-# single-page
+# single-page-hash
 
-write single-page apps with a single callback to handle pushState events
+write single-page apps with support for url hashes and a single callback to handle pushState events
 
 # example
 
@@ -15,17 +15,17 @@ Given some html with elements `#foo`, `#bar`, and `#baz`:
       foo foO fOo fOO Foo FoO FOo FOO
       <div><a href="/bar">bar</a></div>
     </div>
-    
+
     <div id="bar">
       bar baR bAr bAR Bar BaR BAr BAR
-      <div><a href="/baz">baz</a></div>
+      <div><a href="/#baz">baz</a></div>
     </div>
-    
+
     <div id="baz">
       baz baZ bAz bAZ Baz BaZ BAz BAZ
       <div><a href="/foo">foo</a></div>
     </div>
-    
+
     <script src="bundle.js"></script>
   </body>
 </html>
@@ -36,32 +36,31 @@ Note that this module doesn't update the link callbacks for you. You'll need to
 handle that for yourself.
 
 ``` js
-var divs = {
-    foo: document.querySelector('#foo'),
-    bar: document.querySelector('#bar'),
-    baz: document.querySelector('#baz')
-};
+var divs = {}
+divs['foo'] = document.querySelector('#foo')
+divs['bar'] = document.querySelector('#bar')
+divs['#baz'] = document.querySelector('#baz')
 
-var singlePage = require('single-page');
+var singlePage = require('../')
 var showPage = singlePage(function (href) {
-    Object.keys(divs).forEach(function (key) {
-        hide(divs[key]);
-    });
-    
-    var div = divs[href.replace(/^\//, '')];
-    if (div) show(div)
-    else show(divs.foo)
-    
-    function hide (e) { e.style.display = 'none' }
-    function show (e) { e.style.display = 'block' }
+  Object.keys(divs).forEach(function (key) {
+    hide(divs[key])
+  });
+
+  var div = divs[href.replace(/^\//, '')]
+  if (div) show(div)
+  else show(divs.foo)
+
+  function hide (e) { e.style.display = 'none' }
+  function show (e) { e.style.display = 'block' }
 });
 
-var links = document.querySelectorAll('a[href]');
+var links = document.querySelectorAll('a[href]')
 for (var i = 0; i < links.length; i++) {
-    links[i].addEventListener('click', function (ev) {
-        ev.preventDefault();
-        showPage(this.getAttribute('href'));
-    });
+  links[i].addEventListener('click', function (ev) {
+    ev.preventDefault()
+    showPage(this.getAttribute('href'))
+  })
 }
 ```
 
@@ -69,16 +68,16 @@ You'll need to have a server that will serve up the same static content for each
 of the pushState routes. Something like this will work:
 
 ``` js
-var http = require('http');
-var ecstatic = require('ecstatic')(__dirname);
+var http = require('http')
+var ecstatic = require('ecstatic')(__dirname)
 
 var server = http.createServer(function (req, res) {
-    if (/^\/[^\/.]+$/.test(req.url)) {
-        req.url = '/';
-    }
-    ecstatic(req, res);
-});
-server.listen(5000);
+  if (/^\/[^\/.]+$/.test(req.url)) {
+    req.url = '/'
+  }
+  ecstatic(req, res)
+})
+server.listen(5000)
 ```
 
 Now when you go to `http://localhost:5000` and click around, you'll see `/foo`,
@@ -88,7 +87,7 @@ not reloading the page.
 # methods
 
 ``` js
-var singlePage = require('single-page')
+var singlePage = require('single-page-hash')
 ```
 
 ## var showPage = singlePage(cb, opts)
@@ -113,11 +112,21 @@ Update the location href in the address bar without firing any callbacks.
 With `npm` do:
 
 ```
-npm install single-page
+npm install single-page-hash
 ```
 
 Use [browserify](http://browserify.org) do bundle this module into your
 application.
+
+# demo
+
+```
+git clone https://github.com/serapath/single-page.git
+cd single-page
+npm install
+npm start
+# navigate to http://localhost:5001/
+```
 
 # license
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -2,6 +2,8 @@
 
 write single-page apps with support for url hashes and a single callback to handle pushState events
 
+If you don't need support for url hashes, checkout [single-page](https://www.npmjs.com/package/single-page)
+
 # example
 
 Given some html with elements `#foo`, `#bar`, and `#baz`:


### PR DESCRIPTION
Clicking `<a href='/'>Home</a>` while on address bar `/#foo` updates page content to `/` but leaves address bar with `/#foo`. Using `getPathnameWithHash()` fixes  the address bar to `/` too